### PR TITLE
Standardise Ensemble parameter loading with the PACMAN103 tools

### DIFF
--- a/spinnaker_components/ensemble/ensemble-data.c
+++ b/spinnaker_components/ensemble/ensemble-data.c
@@ -24,7 +24,7 @@ United Kingdom                      Canada
 
 #include "spin-nengo-ensemble.h"
 
-bool copy_in_system_region( uint *addr ){
+bool copy_in_system_region( address_t addr ){
   /* We have 7 parameters of a word each in the order:
    * 1. Number of input dimensions D_in
    * 2. Number of output dimensions D_out
@@ -34,49 +34,37 @@ bool copy_in_system_region( uint *addr ){
    * 6. tau_rc
    * 7. Filter decay constant
    */
-  addr += 20;
-  spin1_memcpy( &n_input_dimensions, addr, sizeof( uint ) );
-  addr++;
-  spin1_memcpy( &n_output_dimensions, addr, sizeof( uint ) );
-  addr++;
-  spin1_memcpy( &n_neurons, addr, sizeof( uint ) );
-  addr++;
-  spin1_memcpy( &dt, addr, sizeof( uint ) );
-  addr++;
-  spin1_memcpy( &t_ref, addr, sizeof( uint ) );
-  addr++;
-  spin1_memcpy( &t_rc, addr, sizeof( value_t ) );
-  addr++;
-  spin1_memcpy( &filter, addr, sizeof( value_t ) );
-  addr++;
+  n_input_dimensions  = addr[0];
+  n_output_dimensions = addr[1];
+  n_neurons           = addr[2];
+  dt                  = addr[3];
+  t_ref               = addr[4];
+  t_rc                = addr[5];
+  filter              = addr[6];
 
   return true;
 }
 
-bool copy_in_bias( uint *addr_base ){
+bool copy_in_bias( address_t addr ){
   /* Biases are 1xN, thus we just copy this area of memory. */
-  addr_base += 20 + 7;
-  spin1_memcpy( i_bias, addr_base, n_neurons * sizeof( accum ) );
+  spin1_memcpy( i_bias, addr, n_neurons * sizeof( accum ) );
   return true;
 }
 
-bool copy_in_encoders( uint *addr_base ){
+bool copy_in_encoders( address_t addr ){
   /* Encoders are a N x D_in matrix. */
-  addr_base += 20 + 7 + n_neurons;
-  spin1_memcpy( encoders, addr_base, n_neurons * n_input_dimensions * sizeof( accum ) );
+  spin1_memcpy( encoders, addr, n_neurons * n_input_dimensions * sizeof( accum ) );
   return true;
 }
 
-bool copy_in_decoders( uint *addr_base ){
+bool copy_in_decoders( address_t addr ){
   /* Decoders are a N x D_out matrix. */
-  addr_base += 20 + 7 + n_neurons * (1 + n_input_dimensions);
-  spin1_memcpy( decoders, addr_base, n_neurons * n_output_dimensions * sizeof( accum ) );
+  spin1_memcpy( decoders, addr, n_neurons * n_output_dimensions * sizeof( accum ) );
   return true;
 }
 
-bool copy_in_decoder_keys( uint *addr_base ){
+bool copy_in_decoder_keys( address_t addr ){
   /* Biases are 1xN. */
-  addr_base += 20 + 7 + n_neurons * (1 + n_input_dimensions + n_output_dimensions);
-  spin1_memcpy( output_keys, addr_base, n_output_dimensions * sizeof( uint ) );
+  spin1_memcpy( output_keys, addr, n_output_dimensions * sizeof( uint ) );
   return true;
 }

--- a/spinnaker_components/ensemble/ensemble-data.h
+++ b/spinnaker_components/ensemble/ensemble-data.h
@@ -23,14 +23,15 @@ United Kingdom                      Canada
 *****************************************************************************/
 
 #include "common-impl.h"
+#include "common-typedefs.h"
 
 #ifndef __ENSEMBLE_DATA_H__
 #define __ENSEMBLE_DATA_H__
 
-bool copy_in_system_region( uint *addr ); // Copy in global data
-bool copy_in_bias( uint *addr );          // Copy in bias data
-bool copy_in_encoders( uint *addr );      // Copy in encoders
-bool copy_in_decoders( uint *addr );      // Copy in decoders
-bool copy_in_decoder_keys( uint *addr );  // Copy in decoder keys
+bool copy_in_system_region( address_t addr ); // Copy in global data
+bool copy_in_bias( address_t addr );          // Copy in bias data
+bool copy_in_encoders( address_t addr );      // Copy in encoders
+bool copy_in_decoders( address_t addr );      // Copy in decoders
+bool copy_in_decoder_keys( address_t addr );  // Copy in decoder keys
 
 #endif

--- a/spinnaker_components/ensemble/ensemble-harness.c
+++ b/spinnaker_components/ensemble/ensemble-harness.c
@@ -64,8 +64,11 @@ int c_main( void )
   
   // Set up routing tables
   if( leadAp ){
-    system_lead_app_configured();
+    system_lead_app_configured( );
   }
+
+  // Load core map
+  system_load_core_map( );
 
   // Setup timer tick, start
   spin1_set_timer_tick( dt );

--- a/spinnaker_components/ensemble/ensemble-harness.c
+++ b/spinnaker_components/ensemble/ensemble-harness.c
@@ -62,7 +62,10 @@ int c_main( void )
              t_rc, t_ref, filter
   );
   
-  spin1_set_mc_table_entry(0, 0, 0xFFFFFFE0, 0x00000100);
+  // Set up routing tables
+  if( leadAp ){
+    system_lead_app_configured();
+  }
 
   // Setup timer tick, start
   spin1_set_timer_tick( dt );

--- a/spinnaker_components/ensemble/ensemble-harness.c
+++ b/spinnaker_components/ensemble/ensemble-harness.c
@@ -48,14 +48,14 @@ int c_main( void )
   io_printf( IO_STD, "Testing...\n" );
 
   // Setup buffers, etc.
-  // test_initialise( );
-  uint *address = (uint *) system_load_sram();
-  copy_in_system_region( address );
+  address_t address = system_load_sram();
+  copy_in_system_region( region_start( 1, address ) );
   initialise_buffers( );
-  copy_in_bias( address );
-  copy_in_encoders( address );
-  copy_in_decoders( address );
-  copy_in_decoder_keys( address );
+  copy_in_bias         ( region_start( 2, address ) );
+  copy_in_encoders     ( region_start( 3, address ) );
+  copy_in_decoders     ( region_start( 4, address ) );
+  copy_in_decoder_keys ( region_start( 5, address ) );
+
   io_printf( IO_STD, "N: %d, D_in: %d, D_out: %d, dt: %d, t_rc: %f,"
              " t_ref: %d steps, filter: %f\n",
              n_neurons, n_input_dimensions, n_output_dimensions, dt,

--- a/spinnaker_components/ensemble/spin-nengo-ensemble.h
+++ b/spinnaker_components/ensemble/spin-nengo-ensemble.h
@@ -30,6 +30,7 @@ United Kingdom                      Canada
 #include "spin1_api.h"
 #include "stdfix-full-iso.h"
 #include "ensemble-data.h"
+#include "common-typedefs.h"
 
 typedef accum value_t;
 typedef accum current_t;


### PR DESCRIPTION
This _should_ be tested first, but it removes all the ~~hacky~~ bare pointer arithmetic from the loading functions.  We also now pull in the router configuration if we're the "lead" application on a given chip, and for extra goodness we use the core map for synchronised startup.
