### PR TITLE
Optimisations to neuron update loop

### DIFF
--- a/nengo_spinnaker/ensemble_vertex.py
+++ b/nengo_spinnaker/ensemble_vertex.py
@@ -71,8 +71,8 @@ class EnsembleVertex( graph.Vertex ):
         def uint(x):
             return x
         
-        # tau_rc in seconds
-        spec.write(data=uint(parameters.S1615(self.data.tau_rc).converted))
+        # 1/tau_rc in 1/seconds
+        spec.write(data=uint(parameters.S1615(1. / self.data.tau_rc).converted))
         # filter decay constant
         # TODO: handle multiple filters
         

--- a/spinnaker_components/ensemble/ensemble-data.c
+++ b/spinnaker_components/ensemble/ensemble-data.c
@@ -38,7 +38,7 @@ bool copy_in_system_region( address_t addr ){
   n_output_dimensions = addr[1];
   n_neurons           = addr[2];
   dt                  = addr[3];
-  t_ref               = addr[4];
+  t_ref               = addr[4] << 28;
   one_over_t_rc       = addr[5];
   filter              = addr[6];
 

--- a/spinnaker_components/ensemble/ensemble-data.c
+++ b/spinnaker_components/ensemble/ensemble-data.c
@@ -39,7 +39,7 @@ bool copy_in_system_region( address_t addr ){
   n_neurons           = addr[2];
   dt                  = addr[3];
   t_ref               = addr[4];
-  t_rc                = addr[5];
+  one_over_t_rc       = addr[5];
   filter              = addr[6];
 
   return true;

--- a/spinnaker_components/ensemble/ensemble-harness.c
+++ b/spinnaker_components/ensemble/ensemble-harness.c
@@ -28,8 +28,8 @@ uint n_input_dimensions, n_output_dimensions, n_neurons, dt, t_ref,
      *v_ref_voltage, *output_keys;
 current_t *i_bias;
 accum *encoders, *decoders;
-value_t *ibuf_accumulator, *ibuf_filtered, *output_values, t_rc, filter,
-        *decoded_values;
+value_t *ibuf_accumulator, *ibuf_filtered, *output_values, one_over_t_rc,
+        filter, *decoded_values;
 
 int c_main( void )
 {
@@ -56,10 +56,10 @@ int c_main( void )
   copy_in_decoders     ( region_start( 4, address ) );
   copy_in_decoder_keys ( region_start( 5, address ) );
 
-  io_printf( IO_STD, "N: %d, D_in: %d, D_out: %d, dt: %d, t_rc: %f,"
+  io_printf( IO_STD, "N: %d, D_in: %d, D_out: %d, dt: %d, one_over_t_rc: %f,"
              " t_ref: %d steps, filter: %f\n",
              n_neurons, n_input_dimensions, n_output_dimensions, dt,
-             t_rc, t_ref, filter
+             one_over_t_rc, t_ref, filter
   );
   
   // Set up routing tables

--- a/spinnaker_components/ensemble/ensemble-harness.c
+++ b/spinnaker_components/ensemble/ensemble-harness.c
@@ -59,7 +59,7 @@ int c_main( void )
   io_printf( IO_STD, "N: %d, D_in: %d, D_out: %d, dt: %d, one_over_t_rc: %f,"
              " t_ref: %d steps, filter: %f\n",
              n_neurons, n_input_dimensions, n_output_dimensions, dt,
-             one_over_t_rc, t_ref, filter
+             one_over_t_rc, t_ref >> 28, filter
   );
   
   // Set up routing tables

--- a/spinnaker_components/ensemble/ensemble-update.c
+++ b/spinnaker_components/ensemble/ensemble-update.c
@@ -80,7 +80,7 @@ void timer_callback( uint arg0, uint arg1 )
     }
 
     v_voltage = neuron_voltage(n);
-    v_delta = ( i_membrane - v_voltage ) / t_rc;
+    v_delta = ( i_membrane - v_voltage ) * one_over_t_rc;
     /* io_printf( IO_STD, "dt = %k, J = %k, V = %k, dV = %k\n",
                   dt, i_membrane, v_voltage, v_delta );
     */

--- a/spinnaker_components/ensemble/ensemble-update.c
+++ b/spinnaker_components/ensemble/ensemble-update.c
@@ -35,7 +35,11 @@ void timer_callback( uint arg0, uint arg1 )
   current_t i_membrane;
   voltage_t v_delta, v_voltage;
 
+  // Consider changing this so that we:
+  // 1. Use a power of 2 for the gap between transmitting
+  // 2. Compute this elsewhere
   uint neurons_per_packet = n_output_dimensions / n_neurons;
+  uint n_counter = neurons_per_packet;
   uint n_current_output_dimension = 0;
   
   // For every input dimension, decay the input value and zero the accumulator.
@@ -51,8 +55,8 @@ void timer_callback( uint arg0, uint arg1 )
   for( uint n = 0; n < n_neurons; n++ ) {
     // If this neuron is a multiple of neurons_per_packet then transmit a
     // dimension packet.
-    if( n_current_output_dimension < n_output_dimensions
-     && n % neurons_per_packet == 0 ) {
+    n_counter--;
+    if( n_counter == 0 ){
       // Transmit the packet with the appropriate key
       spin1_send_mc_packet(
         output_keys[ n_current_output_dimension ],
@@ -63,6 +67,7 @@ void timer_callback( uint arg0, uint arg1 )
       // Zero the output buffer and increment the output dimension counter
       output_values[ n_current_output_dimension ] = 0;
       n_current_output_dimension++;
+      n_counter = neurons_per_packet;
     }
 
     // If this neuron is refractory then skip any further processing

--- a/spinnaker_components/ensemble/spin-nengo-ensemble.h
+++ b/spinnaker_components/ensemble/spin-nengo-ensemble.h
@@ -93,7 +93,7 @@ static inline uint neuron_refractory( uint n )
 
 //! Put the given neuron in a refractory state (zero voltage, set timer)
 static inline void set_neuron_refractory( uint n )
-  { v_ref_voltage[n] = t_ref << 28; };
+  { v_ref_voltage[n] = t_ref; };
 
 //! Decrement the refractory time for the given neuron
 static inline void decrement_neuron_refractory( uint n )

--- a/spinnaker_components/ensemble/spin-nengo-ensemble.h
+++ b/spinnaker_components/ensemble/spin-nengo-ensemble.h
@@ -52,7 +52,7 @@ extern uint n_neurons;               //! Number of neurons N
 
 extern uint dt;                      //! Machine time step      [useconds]
 extern uint t_ref;                   //! Refractory period -1    [steps]
-extern value_t t_rc;                 //! Membrane time constant [seconds]
+extern value_t one_over_t_rc;        //! 1 / Membrane time constant [/seconds]
 extern value_t filter;               //! Input decay factor
 
 extern current_t * i_bias;           //! Population biases : 1 x N


### PR DESCRIPTION
Partially courtesy of @neworderofjamie.
- Changed from using `t_rc` to `one_over_t_rc` as this saves us a divide.
- Factored out shifting `t_ref` so that we do this in advance.
- Modified the logic for determining when to send a MC packet so that we lose a mod.
