### PR TITLE
Regularised output for Ensembles using Timer 2

### DIFF
--- a/spinnaker_components/ensemble/ensemble-data.c
+++ b/spinnaker_components/ensemble/ensemble-data.c
@@ -37,6 +37,9 @@ bool copy_in_system_region( address_t addr ){
   one_over_t_rc       = kbits( addr[5] );
   filter              = kbits( addr[6] );
 
+  // Calculate the number of microseconds between transmitting output packets
+  us_per_output = dt / n_output_dimensions;
+
   return true;
 }
 

--- a/spinnaker_components/ensemble/ensemble-harness.c
+++ b/spinnaker_components/ensemble/ensemble-harness.c
@@ -25,7 +25,7 @@ United Kingdom                      Canada
 #include "spin-nengo-ensemble.h"
 
 uint n_input_dimensions, n_output_dimensions, n_neurons, dt, t_ref,
-     *v_ref_voltage, *output_keys;
+     *v_ref_voltage, *output_keys, us_per_output;
 current_t *i_bias;
 accum *encoders, *decoders;
 value_t *ibuf_accumulator, *ibuf_filtered, *output_values, one_over_t_rc,
@@ -61,6 +61,10 @@ int c_main( void )
 
   // Load core map
   system_load_core_map( );
+
+  // Setup Timer2, initialise output loop
+  timer_register( SLOT_8 ); // TODO: Confirm this via testing / ST
+  timer_schedule_proc( outgoing_dimension_callback, 0, 0, us_per_output );
 
   // Setup timer tick, start
   spin1_set_timer_tick( dt );

--- a/spinnaker_components/ensemble/ensemble-io.c
+++ b/spinnaker_components/ensemble/ensemble-io.c
@@ -27,3 +27,36 @@ void incoming_spike_callback( uint key, uint payload )
   uint dimension = key & 0x0000000f;
   ibuf_accumulator[ dimension ] += kbits( payload );
 }
+
+/**
+ * \brief Transmit the value associated with one dimension.
+ * \param index Dimension to transmit a value for.
+ * \param arg1 Unused
+ *
+ * Timer2 is used to ensure that transmission of outgoing MC packets is
+ * regular over time, so as to avoid overloading the network.
+ *
+ * At each interval the value for one dimension is transmitted, and
+ * transmission of the next is scheduled.
+ */
+void outgoing_dimension_callback( uint index, uint arg1 ) {
+  // Transmit the packet with the appropriate key
+  spin1_send_mc_packet(
+    output_keys[ index ],
+    bitsk(output_values[ index ]),
+    WITH_PAYLOAD
+  );
+
+  // Zero the output buffer and increment the output dimension counter
+  output_values[ index ] = 0;
+  index++;
+  
+  if( index >= n_output_dimensions ) {
+    index = 0;
+  }
+
+  // Schedule this function to be called again
+  if( !timer_schedule_proc( (event_proc) outgoing_dimension_callback, index, 0, us_per_output ) ) {
+    io_printf( IO_BUF, "[Timer2] [ERROR] Failed to schedule next.\n" );
+  }
+}

--- a/spinnaker_components/ensemble/spin-nengo-ensemble.h
+++ b/spinnaker_components/ensemble/spin-nengo-ensemble.h
@@ -43,6 +43,7 @@ typedef accum voltage_t;
 int c_main( void );
 void timer_callback( uint arg0, uint arg1 );
 void incoming_spike_callback( uint key, uint payload );
+void outgoing_dimension_callback( uint index, uint arg1 );
 
 /* Initialisation functions **************************************************/
 void initialise_buffers( void );
@@ -52,6 +53,9 @@ extern uint n_input_dimensions;  //!< Number of input dimensions \f$D_{in}\f$
 extern uint n_output_dimensions; //!< Number of output dimensions \f$D_{out}\f$
 extern uint * output_keys;       //!< Output dimension keys \f$1 \times D_{out}\f$
 extern uint n_neurons;           //!< Number of neurons \f$N\f$
+
+extern uint us_per_output;       //!< Microsecond delay between transmitting
+                                 //   decoded output
 
 extern uint dt;                  //!< Machine time step  / useconds
 extern uint t_ref;               //!< Refractory period \f$\tau_{ref} - 1\f$ / steps


### PR DESCRIPTION
- Stripped interleaved output out of neuron update.
- Added new output function.
- Added calculation for delay between output packets.

**This is an unusual use for Timer2, but seems to be acceptable for now.**
