### PR TITLE
Constant Nodes

### DIFF
--- a/nengo_spinnaker/builder.py
+++ b/nengo_spinnaker/builder.py
@@ -50,6 +50,8 @@ class EnsembleData:
         self.N = ens.neurons.n_neurons     # number of neurons
         self.D_in = ens.dimensions
         self.D_out = 0
+
+        self.constant_input = np.zeros( self.D_in )
         
         # Create random number generator
         if ens.seed is None:

--- a/nengo_spinnaker/builder.py
+++ b/nengo_spinnaker/builder.py
@@ -29,8 +29,9 @@ import nengo.build_utils
 
 class NodeData:
     """Constructed information for a Node."""
-    def __init__(self, ens, rng):
+    def __init__(self, node, rng):
         self.filters = []
+        self.node = node
     def get_target(self, filter):
         if filter not in self.filters:
             self.filters.append(filter)

--- a/nengo_spinnaker/builder.py
+++ b/nengo_spinnaker/builder.py
@@ -45,6 +45,7 @@ class EnsembleData:
         self.decoder_list = []      # list of actual decoders (with transform)
         self.ens = ens              # the ensemble we're associated with
         self.label = ens.label
+        self.vertex = None
     
         self.N = ens.neurons.n_neurons     # number of neurons
         self.D_in = ens.dimensions

--- a/nengo_spinnaker/ensemble_vertex.py
+++ b/nengo_spinnaker/ensemble_vertex.py
@@ -82,6 +82,15 @@ class EnsembleVertex( graph.Vertex ):
         spec.write(data=uint(parameters.S1615(decay).converted))
                 
         spec.switchWriteFocus(REGIONS.BIAS)
+        spec.comment( "# *** Bias Currents, including any constant inputs. ***" )
+        # Encode any constant inputs, and add to the biases
+        additional_bias = np.dot(
+            self.data.encoders,
+            self.data.constant_input
+        )
+        self.data.bias += additional_bias
+
+        # Write the bias currents
         for i in range(N):
             spec.write(data=uint(parameters.S1615(self.data.bias[i]).converted))
         

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -2,6 +2,7 @@ from pacman103.core import dao
 from pacman103.core import control
 from pacman103 import conf
 import sys
+import numpy as np
 
 from . import ensemble_vertex   
 from . import transmit_vertex
@@ -47,7 +48,15 @@ class Simulator:
         for c in self.builder.conn_e2n:
             self.dao.add_edge(decoder_edge.DecoderEdge(c, c.pre.vertex, self.tx_vertex))
         for c in self.builder.conn_n2e:
-            self.dao.add_edge(input_edge.InputEdge(self.rx_vertex, c.post.vertex))
+            """If the Node is a constant, then don't bother adding this edge.
+            Instead, add the value of the Node to the constant_input of the
+            receiving ensemble."""
+            if isinstance( c.pre.node.output, np.ndarray ):
+                c.post.constant_input += c.pre.node.output
+            else:
+                self.dao.add_edge(
+                    input_edge.InputEdge(self.rx_vertex, c.post.vertex)
+                )
             
     def pacman_place_and_route(self):
         controller = control.Controller(sys.modules[__name__], 


### PR DESCRIPTION
Constant-valued Nodes which are connected to an Ensemble are instead encoded and included in the bias current of receiving Ensembles.  Unless people are actively using constant Nodes and filters to provide transients this is fine -- in this case we may want to provide some means of marking Nodes which are desired to be transient inputs.

Any thoughts?
