### PR TITLE
Mask input accumulators to save a branch

### DIFF
--- a/nengo_spinnaker/ensemble_vertex.py
+++ b/nengo_spinnaker/ensemble_vertex.py
@@ -295,6 +295,7 @@ class EnsembleVertex(graph.Vertex):
         # 6. dt over tau_rc
         # 7. Filter decay (TO BE CHANGED)
         # 8. 1 - Filter decay (TO BE CHANGED)
+        # 9. Input accumulator mask (TO BE CHANGED - One per filter)
         """)
         subvertex.spec.write(data=self.n_input_dimensions)
         subvertex.spec.write(data=self.n_output_dimensions)
@@ -307,6 +308,10 @@ class EnsembleVertex(graph.Vertex):
             filter = self.filters.filter_tcs(self.dt)
             subvertex.spec.write(data=parameters.s1615(filter[0][0]))
             subvertex.spec.write(data=parameters.s1615(filter[0][1]))
+        else:
+            subvertex.spec.write(data=0, repeats=2)
+
+        subvertex.spec.write(data=0)
 
     def write_region_bias(self, subvertex):
         """Write the bias region for the given subvertex."""

--- a/spinnaker_components/common/dimensional-io.h
+++ b/spinnaker_components/common/dimensional-io.h
@@ -68,8 +68,9 @@ static inline void input_buffer_step( filtered_input_buffer_t *buffer ) {
     buffer->filtered[d] *= buffer->filter;
     buffer->filtered[d] += buffer->accumulator[d] * buffer->n_filter;
 
-    // Zero the accumulator
-    buffer->accumulator[d] = bitsk(buffer->accumulator[d]) & buffer->mask;
+    // Clear or retain the accumulator as required
+    buffer->accumulator[d] = kbits(
+      bitsk(buffer->accumulator[d]) & buffer->mask;)
   }
 }
 

--- a/spinnaker_components/common/dimensional-io.h
+++ b/spinnaker_components/common/dimensional-io.h
@@ -70,7 +70,7 @@ static inline void input_buffer_step( filtered_input_buffer_t *buffer ) {
 
     // Clear or retain the accumulator as required
     buffer->accumulator[d] = kbits(
-      bitsk(buffer->accumulator[d]) & buffer->mask;)
+      bitsk(buffer->accumulator[d]) & buffer->mask);
   }
 }
 

--- a/spinnaker_components/common/dimensional-io.h
+++ b/spinnaker_components/common/dimensional-io.h
@@ -35,6 +35,8 @@ United Kingdom                      Canada
 typedef struct filtered_input_buffer {
   //! Represents a filtered input buffer
   uint d_in;            //!< Number of input dimensions, D_in
+  uint mask;            //!< Mask to apply to accumulator after each input step
+                        //   e.g., all zeroes to clear, all ones to retain.
 
   value_t *accumulator; //!< Accumulates input values, a 1xD_in matrix
   value_t *filtered;    //!< Holds the filtered value, a 1xD_in matrix
@@ -67,7 +69,7 @@ static inline void input_buffer_step( filtered_input_buffer_t *buffer ) {
     buffer->filtered[d] += buffer->accumulator[d] * buffer->n_filter;
 
     // Zero the accumulator
-    buffer->accumulator[d] = 0;
+    buffer->accumulator[d] = bitsk(buffer->accumulator[d]) & buffer->mask;
   }
 }
 

--- a/spinnaker_components/ensemble/ensemble-data.h
+++ b/spinnaker_components/ensemble/ensemble-data.h
@@ -31,6 +31,7 @@ typedef struct region_system {
   value_t dt_over_t_rc;
   value_t filter;
   value_t filter_complement;
+  uint input_accumulator_mask;
 } region_system_t;
 
 /**
@@ -48,6 +49,7 @@ typedef struct region_system {
 * Refactory time constant | Steps | ```uint``` | ::t_ref
 * dt over membrane time constant | | ```accum``` | ::dt_over_t_rc
 * Filter decay constant | | ```accum``` | ::filter
+* Input accumulator mask | | ```uint```
 */
 bool data_system( address_t addr );
 

--- a/spinnaker_components/ensemble/ensemble-input.c
+++ b/spinnaker_components/ensemble/ensemble-input.c
@@ -31,6 +31,7 @@ value_t* initialise_input( region_system_t *pars ){
 
   // Buffer initialisation
   gfib_input = input_buffer_initialise( pars->n_input_dimensions );
+  gfib_input->mask = pars->input_accumulator_mask;
   gfib_input->filter = pars->filter;
   gfib_input->n_filter = pars->filter_complement;
 


### PR DESCRIPTION
To selectively zero or retain input filter accumulators set a mask on the accumulator.  This saves branching multiple times during each filter execution.

For later work this will need to be generalised to provide a mask for each input filter, and to provide a way for connectors to turn on or off the masking/zeroing.
