### PR TITLE
Ensembles with no Decoders, Update loop modifications

### DIFF
--- a/nengo_spinnaker/ensemble_vertex.py
+++ b/nengo_spinnaker/ensemble_vertex.py
@@ -167,7 +167,7 @@ class EnsembleVertex(vertices.NengoVertex):
             self._merged_decoders = np.hstack([d.decoder for d in
                                                self._decoders]) / self.dt
         else:
-            self._merged_decoders = []
+            self._merged_decoders = np.array([[],])
         self._decoder_widths = [d.decoder.shape[1] for d in self._decoders]
         self.n_output_dimensions = self._merged_decoders.shape[1]
 

--- a/nengo_spinnaker/utils/vertices.py
+++ b/nengo_spinnaker/utils/vertices.py
@@ -141,12 +141,19 @@ class NengoVertex(graph.Vertex):
         for region in self._regions:
             size = (region.pre_sizeof(subvertex.n_atoms) if region.sizeof is
                     None else region.sizeof(subvertex))
-            spec.reserveMemRegion(region.index, size * 4)
+            unfilled = region.write is None
+
+            if size > 0:
+                spec.reserveMemRegion(region.index, size*4,
+                                      leaveUnfilled=unfilled)
 
     def __write_regions(self, subvertex, spec):
         for region in self._regions:
-            spec.switchWriteFocus(region.index)
-            region.write(subvertex, spec)
+            size = (region.pre_sizeof(subvertex.n_atoms) if region.sizeof is
+                    None else region.sizeof(subvertex))
+            if region.write is not None and size > 0:
+                spec.switchWriteFocus(region.index)
+                region.write(subvertex, spec)
 
 
 def _region_role_mark(region, role):

--- a/spinnaker_components/ensemble/ensemble-harness.c
+++ b/spinnaker_components/ensemble/ensemble-harness.c
@@ -65,7 +65,7 @@ bool initialise_ensemble(region_system_t *pars) {
     return false;
 
   g_ensemble.output = initialise_output(pars);
-  if (g_ensemble.output == NULL)
+  if (g_ensemble.output == NULL && g_n_output_dimensions > 0)
     return false;
 
   // Register the update function

--- a/spinnaker_components/ensemble/ensemble-output.c
+++ b/spinnaker_components/ensemble/ensemble-output.c
@@ -17,7 +17,7 @@
 
 #include "ensemble-output.h"
 
-uint g_n_output_dimensions, *gp_output_keys, g_output_period;
+uint g_n_output_dimensions, *gp_output_keys;
 value_t * gp_output_values;
 
 // Initialise everything necessary for the output system
@@ -26,19 +26,18 @@ value_t* initialise_output( region_system_t *pars ){
   // Store globals, initialise arrays
   g_n_output_dimensions = pars->n_output_dimensions;
 
-  MALLOC_FAIL_NULL(gp_output_values,
-                   pars->n_output_dimensions * sizeof(value_t),
-                   "[Ensemble]");
-  MALLOC_FAIL_NULL(gp_output_keys,
-                   pars->n_output_dimensions * sizeof(uint),
-                   "[Ensemble]");
+  if (g_n_output_dimensions > 0) {
+    MALLOC_FAIL_NULL(gp_output_values,
+                     pars->n_output_dimensions * sizeof(value_t),
+                     "[Ensemble]");
+    MALLOC_FAIL_NULL(gp_output_keys,
+                     pars->n_output_dimensions * sizeof(uint),
+                     "[Ensemble]");
+  }
 
   io_printf( IO_BUF, "[Ensemble] n_output_dimensions = %d\n",
     g_n_output_dimensions
   );
-
-  // Calculate the number of microseconds between transmitting output packets
-  g_output_period = pars->n_neurons / g_n_output_dimensions;
 
   // Return the output buffer
   return gp_output_values;


### PR DESCRIPTION
- Allow for Ensembles with no-decoders, be a bit more intelligent with malloc return checks.
- All outgoing MC packets are transmitted at the end of the update loop with 1us delays -- this solves #33.
