### PR TITLE
Flexible keyspace

### DIFF
--- a/nengo_spinnaker/edges.py
+++ b/nengo_spinnaker/edges.py
@@ -13,6 +13,8 @@ class NengoEdge(graph.Edge):
         self.conn = conn   # Handy reference
         self._filter_is_accumulatory = filter_is_accumulatory
 
+    dimension_mask = 0x3F  # Mask to extract the dimension from a key
+
     @property
     def width(self):
         utils.get_connection_width(self.conn)

--- a/nengo_spinnaker/edges.py
+++ b/nengo_spinnaker/edges.py
@@ -13,7 +13,14 @@ class NengoEdge(graph.Edge):
         self.conn = conn   # Handy reference
         self._filter_is_accumulatory = filter_is_accumulatory
 
+    mask = 0xFFFFFFC0  # Routing mask for this type of edge
     dimension_mask = 0x3F  # Mask to extract the dimension from a key
+
+    def generate_key(self, x, y, p, i):
+        """Return a key for the edge, this will be used in conjunction with
+        the mask from this class for routing.
+        """
+        return (x << 24) | (y << 16) | ((p-1) << 11) | (i << 6)
 
     @property
     def width(self):

--- a/nengo_spinnaker/ensemble_vertex.py
+++ b/nengo_spinnaker/ensemble_vertex.py
@@ -226,6 +226,7 @@ class EnsembleVertex(vertices.NengoVertex):
 
         for (i, w) in enumerate(self._decoder_widths):
             # Generate the routing keys for each dimension
+            # TODO Use edges to perform this calculation
             for d in range(w):
                 spec.write(data=((x << 24) | (y << 16) | ((p-1) << 11) |
                                  (i << 6) | d))
@@ -234,9 +235,8 @@ class EnsembleVertex(vertices.NengoVertex):
         """Generate a key and mask for the given subedge."""
         x, y, p = subedge.presubvertex.placement.processor.get_coordinates()
         i = self._edge_decoders[subedge.edge]
-        key = (x << 24) | (y << 16) | ((p-1) << 11) | (i << 6)
 
-        return key, 0xFFFFFFE0
+        return subedge.edge.generate_key(x, y, p, i), subedge.edge.mask
 
 
 def _generate_edge_decoder(e, rng):

--- a/nengo_spinnaker/filter_vertex.py
+++ b/nengo_spinnaker/filter_vertex.py
@@ -11,6 +11,8 @@ class FilterVertex(vertices.NengoVertex):
                  output_period=100, constraints=None, label='filter'):
         """Create a new FilterVertex
 
+        We only allow ONE output from a Filter vertex at the moment.
+
         :param dimensions: number of values
         :param output_id: id key to place in packet routing
         :param time_step: Machine timestep (in microseconds)
@@ -58,7 +60,9 @@ class FilterVertex(vertices.NengoVertex):
         """Write the output keys region for the given subvertex."""
         x, y, p = subvertex.placement.processor.get_coordinates()
         i = self.output_id
-        key = (x << 24) | (y << 16) | ((p-1) << 11) | (i << 6)
+
+        assert(len(self.out_edges) == 1)
+        key = self.out_edges[0].generate_key(x, y, p, i)
 
         for d in range(self.dimensions):
             spec.write(data=key | d)
@@ -67,6 +71,5 @@ class FilterVertex(vertices.NengoVertex):
         """Generate a key and mask for the given subedge."""
         x, y, p = subedge.presubvertex.placement.processor.get_coordinates()
         i = self.output_id
-        key = (x << 24) | (y << 16) | ((p-1) << 11) | (i << 6)
 
-        return key, 0xFFFFFFE0
+        return subedge.edge.generate_key(x, y, p, i), subedge.edge.mask

--- a/nengo_spinnaker/nodes/sdp_receive_vertex.py
+++ b/nengo_spinnaker/nodes/sdp_receive_vertex.py
@@ -97,6 +97,7 @@ class SDPReceiveVertex(vertices.NengoVertex):
 
     def get_routing_key_for_node_transform(self, subvertex, node, transform):
         """Get the routing key for the given subvertex, Node and transform."""
+        # TODO Use edges to perform this calculation
         x, y, p = subvertex.placement.processor.get_coordinates()
         i = self.get_routing_id_for_node_transform(node, transform)
         return (x << 24) | (y << 16) | ((p-1) << 11) | (i << 6)
@@ -105,4 +106,4 @@ class SDPReceiveVertex(vertices.NengoVertex):
         key = self.get_routing_key_for_node_transform(subedge.presubvertex,
                                                       subedge.edge.pre,
                                                       subedge.edge.transform)
-        return key, 0xFFFFFFE0
+        return key, subedge.edge.mask

--- a/spinnaker_components/common/filtered-input.h
+++ b/spinnaker_components/common/filtered-input.h
@@ -33,6 +33,7 @@ typedef struct input_filter_key {
   uint key;     //!< MC packet key
   uint mask;    //!< MC packet mask
   uint filter;  //!< ID of filter to use for packets matching this key, mask
+  uint dimension_mask;  //!< Mask to retrieve dimension from key
 } input_filter_key_t;
 
 
@@ -97,24 +98,6 @@ void incoming_dimension_value_callback( uint key, uint payload );
  * Filter the inputs and set the accumulators to zero.
  */
 void input_filter_step( void );
-
-/**
- * \brief Return a pointer to the appropriate input filter for a given key.
- */
-static inline filtered_input_buffer_t* input_filter( uint key ) {
-  // Compare against each key, value pair held in the input
-  for( uint i = 0; i < g_input.n_routes; i++ ) {
-    if( ( key & g_input.routes[i].mask ) == g_input.routes[i].key ) {
-      // Match the given key and mask
-      return g_input.filters[ g_input.routes[i].filter ];
-    }
-  }
-  // No match
-  io_printf(IO_STD, "[Filtered Input] ERROR Could not match incoming packet "
-    "with key %d with filter.\n", key
-  );
-  return NULL;
-};
 
 #endif
 


### PR DESCRIPTION
**Based on #32.**

Moderate support for #34.  Two domains are proposed: the "pure" Nengo domain where keys continue to take the `8{x,y}5{p,i}6d` format (these are the only form of keys _output_ by Ensembles), and an external domain where keys can take a greater variety of forms (as required by Jorg's new robot protocol).  Edges have slightly more control over the form of the key used to represent them, but this has yet to be fully nailed down - regardless, I propose merging this and adding additional flexibility as and when required.

Input is more flexible, with each filter route now also specifying a dimension mask which is applied to a key to extract the dimension.  All components using input filters (Ensembles, Filters, SDP-Tx) have this functionality by default.  The dimension mask is set by the edge (`dimension_mask`) and defaults to 6 bits (`0x3F`).
