### PR TITLE
Fixes issues with multidimensional output Nodes.

### DIFF
--- a/nengo_spinnaker/utils/nodes.py
+++ b/nengo_spinnaker/utils/nodes.py
@@ -144,8 +144,8 @@ class OutputToBoard(object):
         self.node = represent_node
         self.io = io
 
-    def __call__(self, *vs):
-        self.io.set_node_output(self.node, vs[1:])
+    def __call__(self, t, vs):
+        self.io.set_node_output(self.node, vs)
 
 
 class InputFromBoard(object):


### PR DESCRIPTION
Laziness with arguments led to misaligned objects in the output code. Fixed by anticipating `t` directly in `OutputNode` objects.
