### PR TITLE
Fixes for host network generation and probing Pass Nodes

### DIFF
--- a/nengo_spinnaker/builder.py
+++ b/nengo_spinnaker/builder.py
@@ -118,6 +118,11 @@ class Builder(object):
         (objs, connections) = nengo.utils.builder.remove_passthrough_nodes(
             objs, connections)
 
+        # Generate a version of the network to simulate on the host
+        host_network = utils.nodes.create_host_network(
+            [n for n in objs if isinstance(n, nengo.Node)], connections,
+            node_builder.io, config)
+
         # Create a MultiCastVertex
         self._mc_tx_vertex = None
 
@@ -158,8 +163,6 @@ class Builder(object):
 
         # Return the DAO, a reduced version of the network to simulate on the
         # host and a list of probes.
-        host_network = utils.nodes.create_host_network(
-            model, node_builder.io, config)
         return self.dao, host_network, self.probes
 
     def add_vertex(self, vertex):

--- a/nengo_spinnaker/utils/nodes.py
+++ b/nengo_spinnaker/utils/nodes.py
@@ -1,9 +1,10 @@
 import numpy as np
 
 import nengo
+from nengo.utils.builder import objs_and_connections, remove_passthrough_nodes
 
 
-def create_host_network(network, io, config=None):
+def create_host_network(nodes, connections, io, config=None):
     """Create a network of Nodes for simulation on the host.
 
     :returns: A Network with no Ensembles, all Node->Ensemble or Ensemble->Node
@@ -14,7 +15,7 @@ def create_host_network(network, io, config=None):
     new_network = nengo.Network()
 
     # Remove custom built Nodes
-    (ns, conns) = remove_custom_nodes(network.nodes, network.connections)
+    (ns, conns) = remove_custom_nodes(nodes, connections)
 
     # Replace Node -> Ensemble connections
     (ns, conns) = replace_node_ensemble_connections(conns, io, config)

--- a/nengo_spinnaker/utils/nodes.py
+++ b/nengo_spinnaker/utils/nodes.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import nengo
-from nengo.utils.builder import objs_and_connections, remove_passthrough_nodes
 
 
 def create_host_network(nodes, connections, io, config=None):

--- a/nengo_spinnaker/utils/probes.py
+++ b/nengo_spinnaker/utils/probes.py
@@ -35,7 +35,6 @@ def get_corrected_probes(probes, connections):
     """Get a modified list of Probes, removing the synapses from Probes which
     probe PassNodes with synapses on *their* inputs.
     """
-    new_probes = list()
     ins, _ = nengo.utils.builder.find_all_io(connections)
 
     for probe in probes:
@@ -46,14 +45,12 @@ def get_corrected_probes(probes, connections):
             if True in [c.synapse is not None for c in ins[probe.target]]:
                 warnings.warn("Can't currently have synapse on PassNode Probe."
                               "\n\nDefaulting to synapse=None on %s\n"
-                              "This is because you tried to provide a"
-                              "synapse for a PassNode Probe where inputs to"
+                              "This is because you tried to provide a "
+                              "synapse for a PassNode Probe where inputs to "
                               "the PassNode already possessed synapses.\n"
                               % probe, RuntimeWarning)
-                probe = nengo.Probe(probe.target, synapse=None,
-                                    add_to_container=False)
-        new_probes.append(probe)
-    return new_probes
+                probe.conn_args['synapse'] = None
+    return probes
 
 
 def build_ensemble_probenode_edge(builder, c):

--- a/nengo_spinnaker/utils/probes.py
+++ b/nengo_spinnaker/utils/probes.py
@@ -83,7 +83,7 @@ class SpiNNakerProbe(object):
 
 class ProbeNode(nengo.Node):
     def __init__(self, probe, output=None):
-        self.output = lambda t: t  # NOT None!
+        self.output = lambda t, v: t  # NOT None!
         self.probe = probe
         self.size_in = probe.target.size_out
         self.vertex = None


### PR DESCRIPTION
- The host network was generated without flattening or removing pass nodes, this is corrected.  (Thanks for spotting this @neworderofjamie / @tcstewar)
- Custom build Nodes (those with a `spinnaker_build`) method were being disconnected from Nodes on the host.  These connections are now like Node->Ensemble/Ensemble->Node connections when connecting to non-custom build Nodes.
- The probes were being replaced rather than modified when removing the synapse attribute: this led to `KeyErrors` when trying to retrieve output values.
