### PR TITLE
Fix for multidimensional eval_points in decoder caching.

### DIFF
--- a/nengo_spinnaker/utils/decoders.py
+++ b/nengo_spinnaker/utils/decoders.py
@@ -4,6 +4,13 @@ import collections
 import numpy as np
 
 
+def totuple(a):
+    try:
+        return tuple(totuple(i) for i in a)
+    except TypeError:
+        return a
+
+
 FunctionSolverEvals = collections.namedtuple(
     'FunctionSolverEvals', ['function', 'solver', 'eval_points'])
 
@@ -29,11 +36,15 @@ class DecoderBuilder(object):
         """
         for cons, decoder in self.built_decoders.items():
             if (cons.function == function and cons.solver == solver and
-                    np.all(cons.eval_points == eval_points)):
+                    (cons.eval_points is None and eval_points is None or
+                        np.all(np.asarray(cons.eval_points) == eval_points))):
                 break
         else:
             decoder = self.decoder_builder(function, eval_points, solver)
-            key = FunctionSolverEvals(function, solver, eval_points)
+
+            key = FunctionSolverEvals(function, solver,
+                None if eval_points is None else totuple(eval_points))
+
             self.built_decoders[key] = decoder
         return np.dot(decoder, transform.T)
 

--- a/nengo_spinnaker/utils/tests/test_decoders.py
+++ b/nengo_spinnaker/utils/tests/test_decoders.py
@@ -24,7 +24,7 @@ def test_decoder_generation():
                               transform=np.random.normal(size=(3, 3)))  # Share (c3)
 
         c5 = nengo.Connection(a, c, solver=nengo.decoders.LstsqL2())  # Share ()
-        c6 = nengo.Connection(a, c, eval_points=np.random.normal(100)) # !Share
+        c6 = nengo.Connection(a, c, eval_points=np.random.normal((100,2))) # !Share
 
         c7 = nengo.Connection(a, c, transform=3)
 


### PR DESCRIPTION
Attempted to hash Numpy array.

Now we turn the eval_points into a tuple if they're not None.  When we compare eval_points to see if they're already known we first check that both sets of eval_points aren't None, followed by returning the tuple to an array and checking as before.
