### PR TITLE
Changes to make the inter-packet pause of the filter executable changeable.

### DIFF
--- a/nengo_spinnaker/filter_vertex.py
+++ b/nengo_spinnaker/filter_vertex.py
@@ -8,7 +8,8 @@ class FilterVertex(vertices.NengoVertex):
     MODEL_NAME = "nengo_filter"
 
     def __init__(self, dimensions, output_id, dt=0.001, time_step=1000,
-                 output_period=100, constraints=None, label='filter'):
+                 output_period=100, interpacket_pause=1,
+                 constraints=None, label='filter'):
         """Create a new FilterVertex
 
         We only allow ONE output from a Filter vertex at the moment.
@@ -17,10 +18,12 @@ class FilterVertex(vertices.NengoVertex):
         :param output_id: id key to place in packet routing
         :param time_step: Machine timestep (in microseconds)
         :param output_period: Time between output events (in ticks)
+        :param interpacket_pause: Time between output packets (in ticks)
         """
         self.time_step = time_step
         self.output_id = output_id
         self.output_period = output_period
+        self.interpacket_pause = interpacket_pause
         self.dt = dt
 
         self.dimensions = dimensions
@@ -33,7 +36,7 @@ class FilterVertex(vertices.NengoVertex):
     @vertices.region_pre_sizeof('SYSTEM')
     def sizeof_region_system(self, n_atoms):
         """Get the size (in words) of the SYSTEM region."""
-        return 3
+        return 4
 
     @vertices.region_pre_sizeof('OUTPUT_KEYS')
     def sizeof_region_output_keys(self, n_atoms):
@@ -54,6 +57,7 @@ class FilterVertex(vertices.NengoVertex):
         spec.write(data=self.dimensions)
         spec.write(data=self.time_step)
         spec.write(data=self.output_period)
+        spec.write(data=self.interpacket_pause)
 
     @vertices.region_write('OUTPUT_KEYS')
     def write_region_output_keys(self, subvertex, spec):

--- a/nengo_spinnaker/nodes/uart.py
+++ b/nengo_spinnaker/nodes/uart.py
@@ -71,7 +71,7 @@ class UART(object):
         if c.post not in self.nodes_filters:
             # Create the new FilterVertex
             self.nodes_filters[node] = filter_vertex.FilterVertex(
-                c.post.size_in, 0, output_period=10, interpacket_period=50)
+                c.post.size_in, 0, output_period=10, interpacket_pause=50)
             builder.add_vertex(self.nodes_filters[node])
 
             # Connect it to the SerialVertex

--- a/nengo_spinnaker/nodes/uart.py
+++ b/nengo_spinnaker/nodes/uart.py
@@ -71,7 +71,7 @@ class UART(object):
         if c.post not in self.nodes_filters:
             # Create the new FilterVertex
             self.nodes_filters[node] = filter_vertex.FilterVertex(
-                c.post.size_in, 0, output_period=10)
+                c.post.size_in, 0, output_period=10, interpacket_period=50)
             builder.add_vertex(self.nodes_filters[node])
 
             # Connect it to the SerialVertex

--- a/spinnaker_components/filter/filter-main.c
+++ b/spinnaker_components/filter/filter-main.c
@@ -21,7 +21,7 @@ void filter_update(uint ticks, uint arg1) {
     for(uint d = 0; d < g_filter.n_dimensions; d++) {
       val = bitsk(g_filter.input[d]);
       spin1_send_mc_packet(g_filter.keys[d], val, WITH_PAYLOAD);
-      spin1_delay_us(50);
+      spin1_delay_us(g_filter.interpacket_pause);
     }
   }
 }
@@ -30,6 +30,7 @@ bool data_system(address_t addr) {
   g_filter.n_dimensions = addr[0];
   g_filter.machine_timestep = addr[1];
   g_filter.transmission_delay = addr[2];
+  g_filter.interpacket_pause = addr[3];
 
   delay_remaining = g_filter.transmission_delay;
   io_printf(IO_BUF, "[Filter] transmission delay = %d\n", delay_remaining);
@@ -47,8 +48,8 @@ bool data_get_output_keys(address_t addr) {
                     "[Filter]");
   spin1_memcpy(
     g_filter.keys, addr, g_filter.n_dimensions * sizeof(uint));
-  
-  for (int i = 0; i < g_filter.n_dimensions; i++)
+
+  for (uint i = 0; i < g_filter.n_dimensions; i++)
     io_printf(IO_BUF, "g_filter.keys[%d] = %08x\n", i, g_filter.keys[i]);
 
   return true;

--- a/spinnaker_components/filter/filter.h
+++ b/spinnaker_components/filter/filter.h
@@ -25,6 +25,8 @@ typedef struct filter_parameters {
   uint machine_timestep;   //!< Machine time step / useconds
   uint transmission_delay; //!< Number of ticks between output transmissions
 
+  uint interpacket_pause;  //!< Delay in usecs between transmitting packets
+
   uint n_dimensions;       //!< Number of dimensions to represent
 
   value_t *input;          //!< Input buffer


### PR DESCRIPTION
**Merges into `serial`**

@mossblaser If you're happy then please merge this into the serial branch.

Adds a new word to the system region of the FilterVertex.  Value of this word is used to control the period of time between transmitting packets.

No warning made to the user as this is quite low-level, we should probably try to do many more graceful things wrt. IO but currently don't.
