### PR TITLE
Basic Filter Routing Lookup-table Optimisation

### DIFF
--- a/nengo_spinnaker/utils/filters.py
+++ b/nengo_spinnaker/utils/filters.py
@@ -77,10 +77,10 @@ def _post_prepare_routing(self):
     # XXX: Warning: This currently makes use of knowledge of the routing key
     # format used. Additionally, further optimisation is possible which is not
     # done here.
-    
+
     # Intialise the final filter list
     self.__filter_keys = list()
-    
+
     # Internal list of the unoptimised filters
     filter_keys = list()
 
@@ -90,34 +90,37 @@ def _post_prepare_routing(self):
 
         routings = [edge.prevertex.generate_routing_info(se) for se in
                     edge.subedges]
-        
+
         filter_keys.extend(
             [FilterRoute(r[0], r[1], i, dmask) for r in routings])
-    
+
     # We cannot optimise cases where connections from cores on a chip go to
     # different filters. Find these cases
     chip_to_filters = collections.defaultdict(set)
     for key, mask, filter, dimension_mask in filter_keys:
         chip_xy = key & 0xFFFF0000
         chip_to_filters[chip_xy].add(filter)
-    
+
     # Bin optimisable connections by chip and put the rest in the final list.
     optimisable_connections = dict()
     for key, mask, filter, dimension_mask in filter_keys:
         chip_xy = key & 0xFFFF0000
         if len(chip_to_filters[chip_xy]) == 1:
-            optimisable_connections[chip_xy] = (key,mask,filter,dimension_mask)
+            optimisable_connections[chip_xy] = (
+                key, mask, filter, dimension_mask)
         else:
-            self.__filter_keys.append(FilterRoute(key,mask,filter,dimension_mask))
-    
+            self.__filter_keys.append(
+                FilterRoute(key, mask, filter, dimension_mask))
+
     # Optimise any connections possible by compacting the rules for each core
     # into just one rule for the whole chip.
     #
-    # XXX: Also mask off all of the bottom 16 bits since the additional bits set
-    # by the PACMAN router key allocator may be different for cases optimised
-    # together.
+    # XXX: Also mask off all of the bottom 16 bits since the additional bits
+    # set by the PACMAN router key allocator may be different for cases
+    # optimised together.
     for key, mask, filter, dimension_mask in optimisable_connections.values():
-        self.__filter_keys.append(FilterRoute(key & ~0x0000FFFF, mask & ~0x0000FFFF, filter, dimension_mask))
+        self.__filter_keys.append(FilterRoute(
+            key & ~0x0000FFFF, mask & ~0x0000FFFF, filter, dimension_mask))
 
 
 @region_sizeof("FILTER_ROUTING")

--- a/nengo_spinnaker/utils/filters.py
+++ b/nengo_spinnaker/utils/filters.py
@@ -71,10 +71,18 @@ def _write_region_filters(self, subvertex, spec):
 @region_post_prepare('FILTER_ROUTING')
 def _post_prepare_routing(self):
     # For each incoming subedge we write the key, mask and index of the
-    # filter to which it is connected.  At some later point we can try
-    # to combine keys and masks to minimise the number of comparisons
-    # which are made in the SpiNNaker application.
+    # filter to which it is connected. This code attempts to optimise cases
+    # where all incoming connections from one chip all go to the same filter.
+    #
+    # XXX: Warning: This currently makes use of knowledge of the routing key
+    # format used. Additionally, further optimisation is possible which is not
+    # done here.
+    
+    # Intialise the final filter list
     self.__filter_keys = list()
+    
+    # Internal list of the unoptimised filters
+    filter_keys = list()
 
     for edge in self.in_edges:
         i = self.__filters[edge.conn]
@@ -82,9 +90,34 @@ def _post_prepare_routing(self):
 
         routings = [edge.prevertex.generate_routing_info(se) for se in
                     edge.subedges]
-
-        self.__filter_keys.extend(
+        
+        filter_keys.extend(
             [FilterRoute(r[0], r[1], i, dmask) for r in routings])
+    
+    # We cannot optimise cases where connections from cores on a chip go to
+    # different filters. Find these cases
+    chip_to_filters = collections.defaultdict(set)
+    for key, mask, filter, dimension_mask in filter_keys:
+        chip_xy = key & 0xFFFF0000
+        chip_to_filters[chip_xy].add(filter)
+    
+    # Bin optimisable connections by chip and put the rest in the final list.
+    optimisable_connections = dict()
+    for key, mask, filter, dimension_mask in filter_keys:
+        chip_xy = key & 0xFFFF0000
+        if len(chip_to_filters[chip_xy]) == 1:
+            optimisable_connections[chip_xy] = (key,mask,filter,dimension_mask)
+        else:
+            self.__filter_keys.append(FilterRoute(key,mask,filter,dimension_mask))
+    
+    # Optimise any connections possible by compacting the rules for each core
+    # into just one rule for the whole chip.
+    #
+    # XXX: Also mask off all of the bottom 16 bits since the additional bits set
+    # by the PACMAN router key allocator may be different for cases optimised
+    # together.
+    for key, mask, filter, dimension_mask in optimisable_connections.values():
+        self.__filter_keys.append(FilterRoute(key & ~0x0000FFFF, mask & ~0x0000FFFF, filter, dimension_mask))
 
 
 @region_sizeof("FILTER_ROUTING")


### PR DESCRIPTION
Work done in collaboration with @neworderofjamie.

This branch adds basic optimisation for the lookup table used to direct arriving packets to the appropriate filter banks. This optimisation step is both limited in scope and also relies on knowledge of the format of routing keys used which is not available at the point of optimisation. Despite these limitations it is important for networks with large ensembles (see motivation below).

We have both attempted to justify to ourselves that the optimiser is correct and have tested the new code with another non-trivial model (Chris' letter-drawing model) where things appeared to continue to work. I've also tested it on some of the example scripts which also continue to work.
# Motivation

These changes are the result of a six hour bug tracking mission by myself and @neworderofjamie for which three hours can be squarely blamed on ST's flood-fill region specification format which is as epicly badass as it is undocumented.

This optimisation is required to allow Lisanne Huurdeman to run her grid cell model on SpiNNaker. This network essentially consists of a single recurrently-connected 47-dimensional ensemble with an enormous number of neurons which must be split across a number of cores. In a "small" case which fails the ensemble has 6,400 neurons. This is split across roughly 8 chips using approximately all 16 cores on each.

Without optimisation, this resulted in tables many tens of kilobytes in size which exhaust the memory of a core causing it to crash in turn causing loading to fail as it checks for chips being successfully loaded. This causes PACMAN to crash in a place which reveals only the flood-fill region it last loaded in the debug messages. Much reverse engineering later and we found the cores which had been loaded and which crashed and diagnosed the memory exhaustion.

After our simple optimisation pass in the best case only one entry is required per chip which connects to the ensemble. Tests on Lisanne's network will take place tomorrow.

A simplified example of this problem (requires 48-node board) is given below:

```
import numpy as np
import nengo

class NullSolver(nengo.decoders.Solver):
    """A decoder solver which simply does nothing.
    """

    def __init__(self):
        self.weights = False

    def __call__(self, A, Y, rng=None):
        N = A.shape[1]
        D = Y.shape[1]
        return np.zeros((N,D)), {}


model = nengo.Network(label="Large ensemble bug test")

with model:
    null_solver = NullSolver()
    # Problem known to kick-in somewhere around 6000 neurons
    a = nengo.Ensemble(12000, 47, label="a")
    nengo.Connection(a, a, solver=null_solver)

import nengo_spinnaker
sim = nengo_spinnaker.Simulator(model)

# All that matters is that it starts
sim.run(1)
```
