### PR TITLE
Put simulation cleanup code in a try:finally block.

### DIFF
--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -96,7 +96,7 @@ class Simulator(object):
             # simulation time, not pause in the TxRx.
             self.dao.run_time = None
 
-            self.controller.set_tag_output(1, 17895)  # Only required for Ethernet
+            self.controller.set_tag_output(1, 17895)  # Only reqd. for Ethernet
 
             self.controller.map_model()
 
@@ -129,7 +129,11 @@ class Simulator(object):
                                 t = self.dt
                             current_time += t
                     else:
-                        time.sleep(time_in_seconds)
+                        if time_in_seconds is not None:
+                            time.sleep(time_in_seconds)
+                        else:
+                            while True:
+                                time.sleep(10.)
                 except KeyboardInterrupt:
                     logger.debug("Stopping simulation.")
 
@@ -144,7 +148,8 @@ class Simulator(object):
             try:
                 logger.debug("Stopping the application from executing.")
                 if clean:
-                    self.controller.txrx.app_calls.app_signal(self.dao.app_id, 2)
+                    self.controller.txrx.app_calls.app_signal(
+                        self.dao.app_id, 2)
             except Exception:
                 pass
 

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -80,32 +80,33 @@ class Simulator(object):
         self.controller = control.Controller(sys.modules[__name__],
                                              self.machine_name)
 
+        # Preparation functions, set the run time for each vertex
+        for vertex in self.dao.vertices:
+            vertex.runtime = time_in_seconds
+            if hasattr(vertex, 'pre_prepare'):
+                vertex.pre_prepare()
+
+        # PACMANify!
+        self.controller.dao = self.dao
+        self.dao.set_hostname(self.machine_name)
+
+        # TODO: Modify Transceiver so that we can manually check for
+        # application termination  i.e., we want to do something during the
+        # simulation time, not pause in the TxRx.
+        self.dao.run_time = None
+
+        self.controller.set_tag_output(1, 17895)  # Only required for Ethernet
+
+        self.controller.map_model()
+
+        # Preparation functions
+        for vertex in self.dao.vertices:
+            if hasattr(vertex, 'post_prepare'):
+                vertex.post_prepare()
+
+        self.controller.generate_output()
+
         try:
-            # Preparation functions, set the run time for each vertex
-            for vertex in self.dao.vertices:
-                vertex.runtime = time_in_seconds
-                if hasattr(vertex, 'pre_prepare'):
-                    vertex.pre_prepare()
-
-            # PACMANify!
-            self.controller.dao = self.dao
-            self.dao.set_hostname(self.machine_name)
-
-            # TODO: Modify Transceiver so that we can manually check for
-            # application termination  i.e., we want to do something during the
-            # simulation time, not pause in the TxRx.
-            self.dao.run_time = None
-
-            self.controller.set_tag_output(1, 17895)  # Only required for Ethernet
-
-            self.controller.map_model()
-
-            # Preparation functions
-            for vertex in self.dao.vertices:
-                if hasattr(vertex, 'post_prepare'):
-                    vertex.post_prepare()
-
-            self.controller.generate_output()
             self.controller.load_targets()
             self.controller.load_write_mem()
 


### PR DESCRIPTION
This means that when networks are killed e.g. due to a Node crashing (or in the GUI's case, a node raising an exception to end the simulation) the network is cleaned up nicely.

(p.s. @tcstewar though not as late as my award winning commit I do feel that committing stuff after the end of summer school party deserves some (sad) kudos...)
