### PR TITLE
Minor fixes

### DIFF
--- a/nengo_spinnaker/nodes/ethernet.py
+++ b/nengo_spinnaker/nodes/ethernet.py
@@ -254,7 +254,7 @@ class EthernetCommunicator(object):
 
             if np.any(t_output != crxb.buffered_output):
                 with self.output_lock:
-                    crxb.buffered_output[:] = t_output.reshape(output.size)
+                    crxb.buffered_output[:] = t_output.reshape(t_output.size)
                     self.rx_fresh[crxb.rx] = True
 
     @stop_on_keyboard_interrupt

--- a/nengo_spinnaker/utils/decoders.py
+++ b/nengo_spinnaker/utils/decoders.py
@@ -82,7 +82,10 @@ def get_combined_compressed_decoders(decoders, indices=None, headers=None,
     dimsdecs = [get_compressed_decoder(d, threshold) for d in decoders]
 
     # Combine the final decoder
-    decoder = np.hstack([d[1] for d in dimsdecs])
+    if len(dimsdecs) > 0:
+        decoder = np.hstack([d[1] for d in dimsdecs])
+    else:
+        decoder = np.array([])
 
     # Generate the header (header element, index and dimension)
     final_headers = list()

--- a/nengo_spinnaker/utils/tests/test_decoders.py
+++ b/nengo_spinnaker/utils/tests/test_decoders.py
@@ -213,3 +213,8 @@ def test_get_compressed_decoders_with_headers():
     
     assert(cdec.shape == (n_neurons, len(expected_headers)))
     assert(headers == expected_headers)
+
+
+def test_null_decoders():
+    headers, cdec = utils.decoders.get_combined_compressed_decoders(
+        [], headers=[])


### PR DESCRIPTION
- Deals with the case where an Ensemble has no output (and hence no decoders).  The decoder block is allocated to an empty Numpy array rather than trying to `hstack` no arrays.  Added test to ensure that no exceptions are raised for empty decoder lists -- tested with `examples/probe_spikes.py`.
- Under certain cases the Ethernet code applied a transform and then tried to flatten the new array back to the size it was prior to the transform.  This is fixed.

Tested against all examples.
