### PR TITLE
Better handling of missing bitarray for spike probing

### DIFF
--- a/nengo_spinnaker/utils/probes.py
+++ b/nengo_spinnaker/utils/probes.py
@@ -164,7 +164,11 @@ except ImportError:
     # No bitarray, so no spike probing!
     warnings.warn("Cannot import module bitarray: spike probing is disabled",
                   ImportWarning)
-    SpikeProbe = None
+
+    class SpikeProbe(object):
+        def __init__(self, *args, **kwargs):
+            raise NotImplementedError("Spike probing requires the module "
+                                      "'bitarray' to be installed.")
 
 
 @filters.with_filters(2, 3)


### PR DESCRIPTION
Raise `NotImplementedError` if `bitarray` not installed and spikes probing is requested.
