### PR TITLE
Neaten MALLOC_FAIL_X macros.

### DIFF
--- a/spinnaker_components/common/dimensional-io.h
+++ b/spinnaker_components/common/dimensional-io.h
@@ -51,18 +51,13 @@ typedef struct filtered_input_buffer {
 static inline filtered_input_buffer_t* input_buffer_initialise( uint d_in ) {
   // Create the buffer on the heap
   filtered_input_buffer_t *buffer;
-  MALLOC_FAIL_NULL(buffer, sizeof(filtered_input_buffer_t),
-                   "[Common/Filters]");
+  MALLOC_FAIL_NULL(buffer, sizeof(filtered_input_buffer_t));
 
   buffer->d_in = d_in;
 
   // Initialise the buffer accumulator and values
-  MALLOC_FAIL_NULL(buffer->accumulator,
-                   d_in * sizeof(value_t),
-                   "[Common/Filters]");
-  MALLOC_FAIL_NULL(buffer->filtered,
-                   d_in * sizeof(value_t),
-                   "[Common/Filters]");
+  MALLOC_FAIL_NULL(buffer->accumulator, d_in * sizeof(value_t));
+  MALLOC_FAIL_NULL(buffer->filtered, d_in * sizeof(value_t));
 
   for (uint d = 0; d < d_in; d++) {
     buffer->accumulator[d] = 0.0k;

--- a/spinnaker_components/common/input_filter.c
+++ b/spinnaker_components/common/input_filter.c
@@ -14,8 +14,7 @@ value_t* input_filter_initialise(input_filter_t* input,
   input->n_dimensions = n_input_dimensions;
 
   MALLOC_FAIL_NULL(input->input,
-                  input->n_dimensions * sizeof(value_t),
-                  "[Common/Input]");
+                  input->n_dimensions * sizeof(value_t));
 
   // Return the input (to the encoders) buffer
   return input->input;
@@ -31,8 +30,7 @@ bool input_filter_get_filters(input_filter_t* input, address_t filter_region) {
 
   if (input->n_filters > 0) {
     MALLOC_FAIL_FALSE(input->filters,
-                      input->n_filters * sizeof(filtered_input_buffer_t*),
-                      "[Common/Input]");
+                      input->n_filters * sizeof(filtered_input_buffer_t*));
 
     input_filter_data_t* filters = (input_filter_data_t*) (filter_region + 1);
 
@@ -63,8 +61,7 @@ bool input_filter_get_filter_routes(input_filter_t* input,
 
   if (input->n_filters > 0 && input->n_routes > 0) {
     MALLOC_FAIL_FALSE(input->routes,
-                      input->n_routes * sizeof(input_filter_key_t),
-                      "[Common/Input]");
+                      input->n_routes * sizeof(input_filter_key_t));
     spin1_memcpy(input->routes, routing_region + 1, 
                  input->n_routes * sizeof(input_filter_key_t));
 

--- a/spinnaker_components/common/nengo-common.h
+++ b/spinnaker_components/common/nengo-common.h
@@ -6,18 +6,19 @@
  * malloc fail \a DESC and an explanation will be stored in IO_BUF and
  * \a VAL will be returned on behalf of the calling function.
  */
-#define __MALLOC_FAIL(VAR, SIZE, DESC, VAL) \
+#define __MALLOC_FAIL(VAR, SIZE, VAL) \
 do { \
   if ((SIZE) == 0) { \
     VAR = NULL; \
   } else { \
     VAR = spin1_malloc(SIZE); \
     if (VAR == NULL) { \
-      io_printf(IO_BUF, DESC " Failed to malloc " #VAR " (%d bytes)\n", \
-                (SIZE)); \
+      io_printf(IO_BUF, "%s:%d Failed to malloc " #VAR " (%d bytes)\n", \
+                __FILE__, __LINE__, SIZE); \
       return VAL; \
     } else { \
-      io_printf(IO_BUF, DESC " Malloc " #VAR " (%d bytes)\n", (SIZE)); \
+      io_printf(IO_BUF, "%s:%d Malloc " #VAR " (%d bytes)\n", \
+                __FILE__, __LINE__, SIZE); \
     } \
   } \
 } while (0)
@@ -27,15 +28,15 @@ do { \
  *  malloc fail \a DESC will be printed to IO_BUF and NULL will be returned
  *  on behalf of the calling function.
  */
-#define MALLOC_FAIL_NULL(VAR, SIZE, DESC) \
-  __MALLOC_FAIL(VAR, SIZE, DESC, NULL)
+#define MALLOC_FAIL_NULL(VAR, SIZE) \
+  __MALLOC_FAIL(VAR, SIZE, NULL)
 
 /*! \def MALLOC_FAIL_FALSE
  *  Will malloc \a SIZE and save the returned pointer in \a VAR.  Should the
  *  malloc fail \a DESC will be printed to IO_BUF and FALSE will be returned
  *  on behalf of the calling function.
  */
-#define MALLOC_FAIL_FALSE(VAR, SIZE, DESC) \
-  __MALLOC_FAIL(VAR, SIZE, DESC, false)
+#define MALLOC_FAIL_FALSE(VAR, SIZE) \
+  __MALLOC_FAIL(VAR, SIZE, false)
 
 #endif

--- a/spinnaker_components/ensemble/ensemble_harness.c
+++ b/spinnaker_components/ensemble/ensemble_harness.c
@@ -55,13 +55,11 @@ bool initialise_ensemble(region_system_t *pars) {
 
   // Holder for bias currents
   MALLOC_FAIL_FALSE(g_ensemble.i_bias,
-                    g_ensemble.n_neurons * sizeof(current_t),
-                    "[Ensemble]");
+                    g_ensemble.n_neurons * sizeof(current_t));
 
   // Holder for refractory period and voltages
   MALLOC_FAIL_FALSE(g_ensemble.status,
-                    g_ensemble.n_neurons * sizeof(neuron_status_t),
-                    "[Ensemble]");
+                    g_ensemble.n_neurons * sizeof(neuron_status_t));
 
   for (uint n = 0; n < g_ensemble.n_neurons; n++) {
     g_ensemble.status[n].refractory_time = 0;
@@ -71,13 +69,11 @@ bool initialise_ensemble(region_system_t *pars) {
   // Initialise some buffers
   MALLOC_FAIL_FALSE(g_ensemble.encoders,
                     g_ensemble.n_neurons * pars->n_input_dimensions *
-                      sizeof(value_t),
-                    "[Ensemble]");
+                      sizeof(value_t));
 
   MALLOC_FAIL_FALSE(g_ensemble.decoders,
                     g_ensemble.n_neurons * pars->n_output_dimensions *
-                      sizeof(value_t),
-                    "[Ensemble]");
+                      sizeof(value_t));
 
   // Setup subcomponents
   g_ensemble.input = input_filter_initialise(&g_input, pars->n_input_dimensions);

--- a/spinnaker_components/ensemble/ensemble_output.c
+++ b/spinnaker_components/ensemble/ensemble_output.c
@@ -28,11 +28,9 @@ value_t* initialise_output( region_system_t *pars ){
 
   if (g_n_output_dimensions > 0) {
     MALLOC_FAIL_NULL(gp_output_values,
-                     pars->n_output_dimensions * sizeof(value_t),
-                     "[Ensemble]");
+                     pars->n_output_dimensions * sizeof(value_t));
     MALLOC_FAIL_NULL(gp_output_keys,
-                     pars->n_output_dimensions * sizeof(uint),
-                     "[Ensemble]");
+                     pars->n_output_dimensions * sizeof(uint));
 
     for (uint n = 0; n < g_n_output_dimensions; n++) {
       gp_output_values[n] = 0;

--- a/spinnaker_components/ensemble/ensemble_pes.c
+++ b/spinnaker_components/ensemble/ensemble_pes.c
@@ -51,8 +51,7 @@ bool get_pes(address_t address)
   {
     // Allocate memory
     MALLOC_FAIL_FALSE(g_pes_learning_rules,
-                      g_num_pes_learning_rules * sizeof(pes_parameters_t),
-                      "[PES]");
+                      g_num_pes_learning_rules * sizeof(pes_parameters_t));
     
     // Copy learning rules from region into new array
     memcpy(g_pes_learning_rules, &address[1], g_num_pes_learning_rules * sizeof(pes_parameters_t));

--- a/spinnaker_components/ensemble/recording.c
+++ b/spinnaker_components/ensemble/recording.c
@@ -11,8 +11,7 @@ bool record_buffer_initialise(recording_buffer_t *buffer, address_t region,
   buffer->current_frame = UINT32_MAX;  // To cause overflow on first tick
 
   // Create the local buffer
-  MALLOC_FAIL_FALSE(buffer->buffer, buffer->frame_length * sizeof(uint),
-                    "[Recording]");
+  MALLOC_FAIL_FALSE(buffer->buffer, buffer->frame_length * sizeof(uint));
 
   // Zero the local buffers
   for (uint i = 0; i < buffer->frame_length; i++) {

--- a/spinnaker_components/filter/filter_main.c
+++ b/spinnaker_components/filter/filter_main.c
@@ -56,8 +56,7 @@ bool data_system(address_t addr) {
 
 bool data_get_output_keys(address_t addr) {
   MALLOC_FAIL_FALSE(g_filter.keys,
-                    g_filter.size_out * sizeof(uint),
-                    "[Filter]");
+                    g_filter.size_out * sizeof(uint));
   spin1_memcpy(
     g_filter.keys, addr, g_filter.size_out * sizeof(uint));
 
@@ -69,8 +68,7 @@ bool data_get_output_keys(address_t addr) {
 
 bool data_get_transform(address_t addr) {
   MALLOC_FAIL_FALSE(g_filter.transform,
-                    sizeof(value_t) * g_filter.size_in * g_filter.size_out,
-                    "[Filter]");
+                    sizeof(value_t) * g_filter.size_in * g_filter.size_out);
 
   spin1_memcpy(g_filter.transform, addr,
                g_filter.size_in * g_filter.size_out * sizeof(uint));

--- a/spinnaker_components/mc_player/mc_player_main.c
+++ b/spinnaker_components/mc_player/mc_player_main.c
@@ -37,7 +37,7 @@ bool get_packets(address_t source, uint** dest) {
   // Allocate some space for the packets list
   uint* dest_;
 
-  MALLOC_FAIL_FALSE(dest_, source[0] * sizeof(mc_packet_t) + 1, "");
+  MALLOC_FAIL_FALSE(dest_, source[0] * sizeof(mc_packet_t) + 1);
   dest[0] = dest_;
 
   // Copy those packets across

--- a/spinnaker_components/sdp_rx/sdp-rx-main.c
+++ b/spinnaker_components/sdp_rx/sdp-rx-main.c
@@ -48,15 +48,9 @@ bool data_system(address_t addr) {
             g_sdp_rx.transmission_period);
   io_printf(IO_BUF, "[SDP Rx] %d dimensions.\n", g_sdp_rx.n_dimensions);
 
-  MALLOC_FAIL_FALSE(g_sdp_rx.output,
-                    g_sdp_rx.n_dimensions * sizeof(value_t),
-                    "[Rx]");
-  MALLOC_FAIL_FALSE(g_sdp_rx.fresh,
-                    g_sdp_rx.n_dimensions * sizeof(bool),
-                    "[Rx]");
-  MALLOC_FAIL_FALSE(g_sdp_rx.keys,
-                    g_sdp_rx.n_dimensions * sizeof(uint),
-                    "[Rx]");
+  MALLOC_FAIL_FALSE(g_sdp_rx.output, g_sdp_rx.n_dimensions * sizeof(value_t));
+  MALLOC_FAIL_FALSE(g_sdp_rx.fresh, g_sdp_rx.n_dimensions * sizeof(bool));
+  MALLOC_FAIL_FALSE(g_sdp_rx.keys, g_sdp_rx.n_dimensions * sizeof(uint));
 
   return true;
 }

--- a/spinnaker_components/value_source/slots.h
+++ b/spinnaker_components/value_source/slots.h
@@ -17,7 +17,7 @@ typedef struct _slots_t {
 static inline bool initialise_slots(slots_t* slots, uint size) {
   // Initialise the slots with the given size
   for (uint i = 0; i < 2; i++) {
-    MALLOC_FAIL_FALSE(slots->slots[i].data, size, "[Slots]");
+    MALLOC_FAIL_FALSE(slots->slots[i].data, size);
     slots->slots[i].current_pos = 0;
     slots->slots[i].length = 0;
   }


### PR DESCRIPTION
Macro now uses `__FILE__` and `__LINE__` rather than `DESC` variable when printing success or error messages.
